### PR TITLE
fix: correct typos in Amenities and FAQ (Neaby→Nearby, school are→schools are)

### DIFF
--- a/src/components/common/Navbar/style.js
+++ b/src/components/common/Navbar/style.js
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { Container } from '@components/global';
 
 export const Nav = styled.nav`
-  padding: 16px 1000;
+  padding: 16px 0;
   background-color: ${props => props.theme.color.primary};
   position: fixed;
   width: 100%;

--- a/src/components/sections/Amenities.js
+++ b/src/components/sections/Amenities.js
@@ -37,7 +37,7 @@ const AMENITIES = [
     role: 'Relax and enjoy the calm water',
   },
   {
-    name: 'Boat Docks Neaby',
+    name: 'Boat Docks Nearby',
     image: 'dock.jpg',
     role: 'Easy to access',
   },

--- a/src/components/sections/Faq.js
+++ b/src/components/sections/Faq.js
@@ -32,7 +32,7 @@ const FAQS = [
     ),
   },
   {
-    title: 'What school are nearby Hidden Acres?',
+    title: 'What schools are nearby Hidden Acres?',
     content: () => (
       <>
         The schools around us include: <a href="https://www.princetonisd.net/harper" target="_blank" rel="noopener noreferrer">Harper Elementary School</a>, <a href="https://www.princetonisd.net/Domain/148" target="_blank" rel="noopener noreferrer">Clark Jr High School</a>, and <a href="https://www.princetonisd.net/Domain/52" target="_blank" rel="noopener noreferrer">Princeton High School</a>. All of which are in Princeton ISD.


### PR DESCRIPTION
## Summary
Fixes two content typos identified in the user-facing copy:

## Changes
- `src/components/sections/Amenities.js`: `'Boat Docks Neaby'` → `'Boat Docks Nearby'`
- `src/components/sections/Faq.js`: `'What school are nearby Hidden Acres?'` → `'What schools are nearby Hidden Acres?'`

## Related
Fixes [Issue #12](https://github.com/VijitSingh97/HiddenAcresRV/issues/12)