### PR TITLE
fix: correct invalid CSS padding value in Navbar (padding: 16px 1000 → padding: 16px 0)

### DIFF
--- a/src/components/common/Navbar/style.js
+++ b/src/components/common/Navbar/style.js
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { Container } from '@components/global';
 
 export const Nav = styled.nav`
-  padding: 16px 1000;
+  padding: 16px 0;
   background-color: ${props => props.theme.color.primary};
   position: fixed;
   width: 100%;


### PR DESCRIPTION
## Summary
Fixes invalid CSS in the Navbar component where `padding: 16px 1000;` has a unitless value, causing the browser to silently discard the entire declaration.

## Change
- `padding: 16px 1000;` → `padding: 16px 0;` in `src/components/common/Navbar/style.js`

## Verification
- CSS now parses correctly; unitless value no longer causes silent failure
- Fixed navbar layout applies as intended

## Related
Fixes [Issue #9](https://github.com/VijitSingh97/HiddenAcresRV/issues/9)