### PR TITLE
fix: correct typos in Amenities and FAQ sections

### DIFF
--- a/src/components/sections/Amenities.js
+++ b/src/components/sections/Amenities.js
@@ -37,7 +37,7 @@ const AMENITIES = [
     role: 'Relax and enjoy the calm water',
   },
   {
-    name: 'Boat Docks Neaby',
+    name: 'Boat Docks Nearby',
     image: 'dock.jpg',
     role: 'Easy to access',
   },

--- a/src/components/sections/Faq.js
+++ b/src/components/sections/Faq.js
@@ -32,7 +32,7 @@ const FAQS = [
     ),
   },
   {
-    title: 'What school are nearby Hidden Acres?',
+    title: 'What schools are near Hidden Acres?',
     content: () => (
       <>
         The schools around us include: <a href="https://www.princetonisd.net/harper" target="_blank" rel="noopener noreferrer">Harper Elementary School</a>, <a href="https://www.princetonisd.net/Domain/148" target="_blank" rel="noopener noreferrer">Clark Jr High School</a>, and <a href="https://www.princetonisd.net/Domain/52" target="_blank" rel="noopener noreferrer">Princeton High School</a>. All of which are in Princeton ISD.


### PR DESCRIPTION
## Description
Fixes two typos found in the Amenities and FAQ sections.

- **Amenities**: "Boat Docks Neaby" → "Boat Docks Nearby"
- **FAQ**: "What school are nearby Hidden Acres?" → "What schools are near Hidden Acres?"

Closes #33

---
*Reported by [GitScope](https://gitscope-micro.vercel.app) — free repo analysis tool*