### PR TITLE
fix: correct invalid CSS padding value in Navbar

### DIFF
--- a/src/components/common/Navbar/style.js
+++ b/src/components/common/Navbar/style.js
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { Container } from '@components/global';
 
 export const Nav = styled.nav`
-  padding: 16px 1000;
+  padding: 16px 0;
   background-color: ${props => props.theme.color.primary};
   position: fixed;
   width: 100%;


### PR DESCRIPTION
## Description
Fixes invalid CSS padding value in the Navbar component.

**Before:** `padding: 16px 1000;` (1000px horizontal padding = layout breaking)
**After:** `padding: 16px 0;` (zero horizontal padding = normal flow)

Closes #32

---
*Found via [GitScope](https://gitscope-micro.vercel.app) — free repo analysis tool*