### PR TITLE
Restore Google Analytics after Hugo rebuild

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -40,7 +40,7 @@ disableKinds = ["taxonomy", "term", "rss"]
 # Analytics 4, paste your Measurement ID (looks like G-XXXXXXXXXX) below. Nothing
 # loads until you do, and never during local previews. See layouts/partials/analytics.html.
 [services.googleAnalytics]
-  ID = ""
+  ID = "G-5P1LKH0N84"
 
 # -----------------------------------------------------------------------------
 #  [params] — site-wide facts. Change a phone number, address, or link once here


### PR DESCRIPTION
## What & why

The Hugo rebuild (#34) kept the GA4 analytics scaffolding but left the Measurement ID blank (`ID = ""`), so **no analytics have been collected since the rebuild**.

Tracing git history: the old Gatsby site read its ID from a `GOOGLE_ANALYTICS_TRACKING_ID` env var that was never committed, so the value couldn't be recovered from the repo. (It was also already an orphaned, unwired dependency in the final pre-rebuild Gatsby state.) This PR plugs the GA4 Measurement ID into the existing Hugo wiring.

## Change

`hugo.toml` — set the GA4 Measurement ID:
```toml
[services.googleAnalytics]
  ID = "G-5P1LKH0N84"
```

No other changes needed — the partial (`layouts/partials/analytics.html` → `layouts/_default/baseof.html`) was already in place.

## Verification (local production build)

- ✅ `gtag.js` snippet renders with the ID: `googletagmanager.com/gtag/js?id=G-5P1LKH0N84` + `gtag('config', 'G-5P1LKH0N84')`
- ✅ Present on every real page (home + 404)
- ✅ Production-gated via `hugo.IsProduction` — does **not** fire during local `hugo server` previews
- ✅ The only page without the snippet is the legacy `/Hidden-Acres-RV-Park/OverView/` redirect stub (0-second meta-refresh to `/`, which is tracked) — expected

After merge & deploy, confirm in GA → **Reports → Realtime**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)