### PR TITLE
Add repo hygiene tooling: Dependabot, shellcheck, yamllint, editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# Consistent whitespace across editors — https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.md]
+# Trailing double-spaces are meaningful line breaks in Markdown.
+trim_trailing_whitespace = false

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# Dependabot — keeps the GitHub Actions in ci.yml up to date automatically.
+# (This site has no npm/Go module tree, so Actions are the only dependencies.)
+# Docs: https://docs.github.com/en/code-security/dependabot
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    # One combined PR instead of one per action — less noise for a quiet repo.
+    groups:
+      github-actions:
+        patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,18 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # --- Lint the scripts and YAML on every push and PR -----------------------
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: shellcheck (test.sh)
+        run: shellcheck test.sh    # preinstalled on ubuntu runners
+      - name: yamllint (data/ + .github/)
+        run: |
+          pipx install yamllint
+          yamllint .
+
   # --- Build the site and validate the HTML on every push and PR -----------
   build:
     runs-on: ubuntu-latest

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,11 @@
+# yamllint config — validates the YAML in data/ and .github/.
+# Run locally with: yamllint .    (install: brew install yamllint)
+extends: default
+
+rules:
+  # Prose lives in these files; don't fight over line width or doc markers.
+  line-length: disable
+  document-start: disable
+  # GitHub Actions uses "on:" which yamllint's default flags as a truthy key.
+  truthy:
+    check-keys: false

--- a/test.sh
+++ b/test.sh
@@ -13,29 +13,55 @@
 #  Needs:    Hugo (extended).  htmltest is optional and auto-detected.
 #  See:      docs/TESTING.md for what each check protects.
 # =============================================================================
+# shellcheck disable=SC2015  # `[ … ] && ok || no` is safe here: ok/no never fail
 set -uo pipefail
-cd "$(dirname "$0")"
+cd "$(dirname "$0")" || exit 1
 
-if [ -t 1 ]; then G=$'\033[32m'; R=$'\033[31m'; Z=$'\033[0m'; else G=; R=; Z=; fi
-pass=0; fail=0
-ok()  { printf '  %s✓%s %s\n' "$G" "$Z" "$1"; pass=$((pass+1)); }
-no()  { printf '  %s✗ %s%s\n' "$R" "$1" "$Z"; fail=$((fail+1)); }
-has() { if grep -qF -- "$1" public/index.html; then ok "$2"; else no "$2"; fi; }          # substring
+if [ -t 1 ]; then
+  G=$'\033[32m'
+  R=$'\033[31m'
+  Z=$'\033[0m'
+else
+  G=
+  R=
+  Z=
+fi
+pass=0
+fail=0
+ok() {
+  printf '  %s✓%s %s\n' "$G" "$Z" "$1"
+  pass=$((pass + 1))
+}
+no() {
+  printf '  %s✗ %s%s\n' "$R" "$1" "$Z"
+  fail=$((fail + 1))
+}
+has() { if grep -qF -- "$1" public/index.html; then ok "$2"; else no "$2"; fi; } # substring
 isfile() { if [ -f "public/$1" ]; then ok "$1"; else no "$1 (missing)"; fi; }
-count() { grep -oE "$1" public/index.html | wc -l | tr -d ' '; }                          # # of matches
+count() { grep -oE "$1" public/index.html | wc -l | tr -d ' '; } # # of matches
 
 # --- 1. Strict build ---------------------------------------------------------
 echo "==> Building (strict — warnings fail the build)…"
-command -v hugo >/dev/null 2>&1 || { echo "✗ Hugo is not installed — see README.md."; exit 1; }
-hugo --gc --minify --panicOnWarning || { echo "✗ Build failed."; exit 1; }
+command -v hugo >/dev/null 2>&1 || {
+  echo "✗ Hugo is not installed — see README.md."
+  exit 1
+}
+hugo --gc --minify --panicOnWarning || {
+  echo "✗ Build failed."
+  exit 1
+}
 
 # --- 2. HTML & internal-link validation -------------------------------------
 if ! command -v htmltest >/dev/null 2>&1 && [ -x "$(go env GOPATH 2>/dev/null)/bin/htmltest" ]; then
-  export PATH="$(go env GOPATH)/bin:$PATH"
+  PATH="$(go env GOPATH)/bin:$PATH"
+  export PATH
 fi
 if command -v htmltest >/dev/null 2>&1; then
   echo "==> Validating HTML & internal links (htmltest)…"
-  htmltest || { echo "✗ htmltest found problems."; exit 1; }
+  htmltest || {
+    echo "✗ htmltest found problems."
+    exit 1
+  }
 else
   echo "⚠ htmltest not installed — skipping link validation."
   echo "  Install once with:  go install github.com/wjdp/htmltest@latest"
@@ -45,13 +71,13 @@ echo "==> Checking the built page…"
 
 # --- 3a. Booking & contact — the conversion paths that matter most -----------
 has 'app.fireflyreservations.com/reserve?propertyGUID=8b116da5' 'Reservation link present & correct'
-has 'reserve/joinwaitlist?propertyGUID=8b116da5'                'Waitlist link present'
-has 'tel:9727361264'                                            'Tap-to-call phone link'
-has 'mailto:reservations@hiddenacresrv.com'                     'Email link'
+has 'reserve/joinwaitlist?propertyGUID=8b116da5' 'Waitlist link present'
+has 'tel:9727361264' 'Tap-to-call phone link'
+has 'mailto:reservations@hiddenacresrv.com' 'Email link'
 
 # --- 3b. Navigation — every menu anchor lands on a real section --------------
 for s in about amenities gallery location faq; do
-  if grep -qF "#$s" public/index.html && grep -qE "id=\"?$s[\" >/]" public/index.html; then
+  if grep -qF "#$s" public/index.html && grep -qE "id=\"?${s}[\" >/]" public/index.html; then
     ok "Nav '#$s' → matching section"
   else
     no "Nav '#$s' has no matching section"
@@ -61,18 +87,18 @@ done
 # --- 3c. Interactions (native HTML/CSS + the one lazy-map script) -----------
 faqs=$(count '<details')
 [ "$faqs" -ge 8 ] && ok "FAQ accordion present ($faqs <details>)" || no "FAQ accordion missing (found $faqs)"
-has 'nav-toggle'     'Mobile menu toggle present'
-has 'nav-burger'     'Mobile menu button present'
-has 'map-facade'     'Interactive map (lazy facade) present'
+has 'nav-toggle' 'Mobile menu toggle present'
+has 'nav-burger' 'Mobile menu button present'
+has 'map-facade' 'Interactive map (lazy facade) present'
 has 'data-map-embed' 'Map embed URL wired up'
 
 # --- 3d. Content the visitor needs ------------------------------------------
 amen=$(count 'amenity-card')
 [ "$amen" -ge 8 ] && ok "Amenities rendered ($amen cards)" || no "Amenities missing (found $amen)"
-has 'attraction-list'    'Local attractions list present'
-has 'TUPPS'              'Attractions look current (TUPPS Brewery)'
+has 'attraction-list' 'Local attractions list present'
+has 'TUPPS' 'Attractions look current (TUPPS Brewery)'
 has 'Driving directions' 'Driving directions present'
-has 'Full hookups'       'Highlight pills present'
+has 'Full hookups' 'Highlight pills present'
 
 # --- 3e. Accessibility ------------------------------------------------------
 h1=$(count '<h1')
@@ -88,20 +114,19 @@ noop=$(count 'noopener')
 [ "$noop" -ge "$blanks" ] && ok "All $blanks new-tab links use rel=noopener" || no "$blanks new-tab links but only $noop noopener"
 
 # --- 3g. SEO essentials ------------------------------------------------------
-has '<title>'             'Page title'
-has 'canonical'           'Canonical URL'
-has 'og:image'            'Open Graph share image'
+has '<title>' 'Page title'
+has 'canonical' 'Canonical URL'
+has 'og:image' 'Open Graph share image'
 has 'application/ld+json' 'JSON-LD structured data'
-has 'viewport'            'Responsive viewport'
+has 'viewport' 'Responsive viewport'
 if command -v python3 >/dev/null 2>&1; then
-  if python3 - <<'PY' 2>/dev/null
+  if python3 - <<'PY' 2>/dev/null; then ok "JSON-LD is valid and complete"; else no "JSON-LD invalid or missing fields"; fi
 import re, sys, json
 h = open('public/index.html', encoding='utf-8').read()
 m = re.search(r'application/ld\+json[^>]*>(.*?)</script>', h, re.S)
 d = json.loads(m.group(1))
 sys.exit(0 if all(k in d for k in ('@type','name','address','geo','telephone')) else 1)
 PY
-  then ok "JSON-LD is valid and complete"; else no "JSON-LD invalid or missing fields"; fi
 fi
 
 # --- 3h. Files search engines & browsers expect -----------------------------
@@ -115,6 +140,6 @@ echo
 if [ "$fail" -eq 0 ]; then
   printf '%s✓ All %d checks passed.%s\n' "$G" "$pass" "$Z"
 else
-  printf '%s✗ %d of %d checks failed.%s\n' "$R" "$fail" "$((pass+fail))" "$Z"
+  printf '%s✗ %d of %d checks failed.%s\n' "$R" "$fail" "$((pass + fail))" "$Z"
   exit 1
 fi


### PR DESCRIPTION
## What

Adds lightweight developer tooling for repo hygiene, keeping with the site's zero-npm ethos:

- **`.github/dependabot.yml`** — monthly updates for the GitHub Actions in CI (the repo's only dependency surface), grouped into a single PR to keep noise down.
- **CI `lint` job** — runs `shellcheck test.sh` (preinstalled on ubuntu runners) and `yamllint .` (data files + workflows) in parallel with the build.
- **`.yamllint.yml`** — default rules with line-length/document-start relaxed, since the `data/` files hold prose.
- **`.editorconfig`** — 2-space / LF / UTF-8 across editors.

## Fixes found along the way

shellcheck flagged three real issues in `test.sh`, now fixed:
- unchecked `cd` (SC2164)
- `export PATH="$(…)"` masking the command's exit status (SC2155)
- unbraced `$s[` in a grep pattern that bash could misparse as an array (SC1087)

The intentional `[ … ] && ok || no` idiom is documented and suppressed with a file-level directive. The script was also reformatted shfmt-style.

Deliberately skipped: markdownlint (needs npm), actionlint (one rarely-changed workflow), CodeQL (no application code).

## Testing

- `./test.sh` — all 33 checks pass
- `shellcheck test.sh` — clean
- `yamllint .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)