### PR TITLE
Add FAQPage schema + generated llms.txt for AI/SEO discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ secure, and nearly maintenance-free for years.
 
 - **Zero-dependency static architecture** — no Node or npm tree to patch; almost nothing to keep secure
 - **Performance-first** — ships ~no JavaScript (one tiny click-to-load map script), self-hosted fonts, and build-time responsive WebP images
-- **SEO & local discovery** — JSON-LD `Campground`/`RVPark` schema, accurate geo, sitemap, robots, and Open Graph
+- **SEO & AI discovery** — JSON-LD `Campground`/`RVPark` + `FAQPage` schema, accurate geo, sitemap, robots, Open Graph, and a generated [`/llms.txt`](https://llmstxt.org) so AI assistants can recommend the park accurately
 - **Accessibility** — semantic landmarks, a single `<h1>`, real alt text, keyboard support, and visible focus styles
 - **Content/layout separation** — every word lives in plain config/data files, so the owner updates text without touching templates
 - **CI/CD + testing** — every push is built, link-checked, and SEO-asserted, then deployed to GitHub Pages

--- a/hugo.toml
+++ b/hugo.toml
@@ -33,8 +33,18 @@ disableKinds = ["taxonomy", "term", "rss"]
   baseName = "site"
   isPlainText = true
   notAlternative = true
+
+# Emit /llms.txt — a clean, plain-text profile of the park (contact, rates,
+# amenities, FAQ) so AI assistants can recommend and answer questions about it
+# accurately. Generated from the same data/ + params, so it never goes stale.
+# Convention: https://llmstxt.org  Template: layouts/index.llms.txt
+[outputFormats.LLMS]
+  mediaType = "text/plain"
+  baseName = "llms"
+  isPlainText = true
+  notAlternative = true
 [outputs]
-  home = ["HTML", "WebAppManifest"]
+  home = ["HTML", "WebAppManifest", "LLMS"]
 
 # Visitor analytics — Google Analytics 4 is ENABLED with the Measurement ID below.
 # To disable tracking, set ID to "" (nothing loads without an ID, and never during

--- a/layouts/index.llms.txt
+++ b/layouts/index.llms.txt
@@ -1,0 +1,33 @@
+{{- $p := site.Params -}}
+{{- $rulesURL := "park_rules/campground-rules.pdf" | absURL -}}
+# {{ $p.brand }}
+
+> {{ $p.description }}
+
+{{ $p.brand }} is an RV park in {{ $p.address.city }}, {{ $p.address.state }}, on the shores of Lake Lavon — {{ lower $p.tagline }}. Website: {{ site.BaseURL }}
+
+## Contact & booking
+- Address: {{ $p.address.street }}, {{ $p.address.city }}, {{ $p.address.state }} {{ $p.address.zip }}
+- Phone: {{ $p.phone }}
+- Email: {{ $p.email }}
+- Rates: from {{ $p.priceFrom }} per night
+- Reserve online: {{ $p.links.reserve }}
+- Join the waitlist: {{ $p.links.waitlist }}
+- Map & directions: {{ $p.links.map }}
+- Park rules (PDF): {{ $rulesURL }}
+
+## Highlights
+{{ range hugo.Data.highlights }}- {{ . }}
+{{ end }}
+## Amenities
+{{ range hugo.Data.amenities }}- {{ .name }}: {{ .blurb }}
+{{ end }}
+## Frequently asked questions
+{{ range hugo.Data.faqs }}### {{ .question }}
+{{ $a := .answer -}}
+{{ $a = replace $a "{{reserve}}" $p.links.reserve -}}
+{{ $a = replace $a "{{waitlist}}" $p.links.waitlist -}}
+{{ $a = replace $a "{{rules}}" $rulesURL -}}
+{{ $a | markdownify | plainify | htmlUnescape | strings.TrimSpace }}
+
+{{ end -}}

--- a/layouts/partials/schema.html
+++ b/layouts/partials/schema.html
@@ -57,3 +57,22 @@
 <script type="application/ld+json">
 {{ $data | jsonify (dict "indent" "  ") | safeJS }}
 </script>
+{{- /* FAQPage: the same Q&A shown on the page, so Google (rich results) and AI
+       assistants can quote accurate answers about pets, rates, rules, etc.
+       Answers mirror faq.html — expand the {{shortcodes}} and render markdown. */ -}}
+{{- $rulesURL := "park_rules/campground-rules.pdf" | absURL -}}
+{{- $questions := slice -}}
+{{- range hugo.Data.faqs -}}
+  {{- $a := .answer -}}
+  {{- $a = replace $a "{{reserve}}" $p.links.reserve -}}
+  {{- $a = replace $a "{{waitlist}}" $p.links.waitlist -}}
+  {{- $a = replace $a "{{rules}}" $rulesURL -}}
+  {{- $questions = $questions | append (dict
+    "@type" "Question"
+    "name" .question
+    "acceptedAnswer" (dict "@type" "Answer" "text" (string ($a | markdownify)))) -}}
+{{- end -}}
+{{- $faq := dict "@context" "https://schema.org" "@type" "FAQPage" "mainEntity" $questions -}}
+<script type="application/ld+json">
+{{ $faq | jsonify (dict "indent" "  ") | safeJS }}
+</script>

--- a/test.sh
+++ b/test.sh
@@ -118,6 +118,7 @@ has '<title>' 'Page title'
 has 'canonical' 'Canonical URL'
 has 'og:image' 'Open Graph share image'
 has 'application/ld+json' 'JSON-LD structured data'
+has 'FAQPage' 'FAQ structured data (rich results + AI answers)'
 has 'viewport' 'Responsive viewport'
 if command -v python3 >/dev/null 2>&1; then
   if python3 - <<'PY' 2>/dev/null; then ok "JSON-LD is valid and complete"; else no "JSON-LD invalid or missing fields"; fi
@@ -134,6 +135,7 @@ isfile sitemap.xml
 isfile robots.txt
 isfile site.webmanifest
 isfile 404.html
+isfile llms.txt
 
 # --- Summary -----------------------------------------------------------------
 echo


### PR DESCRIPTION
## What

The SEO audit came back strong (rich `Campground`/`RVPark` JSON-LD, canonical, OG/Twitter, sitemap, allow-all robots). This closes the two gaps that matter for **AI assistants recommending and reviewing the park**, both built from data already in the repo:

- **`FAQPage` JSON-LD** — the 8 Q&As from `data/faqs.yaml` were rendered on the page but absent from structured data. Now they're machine-readable: eligible for Google FAQ rich results and directly quotable by LLMs answering "does Hidden Acres allow pets / what are the rates / any background check". Answers mirror `faq.html` exactly (same shortcode expansion + markdown).
- **`/llms.txt`** ([llmstxt.org](https://llmstxt.org)) — a clean plain-text profile (contact, rates, amenities, full FAQ) generated as a Hugo output format from the same params + data, so it **never drifts**. Mirrors the existing `WebAppManifest` output-format pattern.

AI crawler access needs nothing new — `robots.txt` is already `User-agent: * / Allow: /`, which permits GPTBot, ClaudeBot, PerplexityBot, etc.

## Testing

- `./test.sh` — **35/35** (added FAQPage + llms.txt assertions)
- FAQPage validated as parseable JSON-LD with all 8 questions carrying answer text
- `llms.txt` verified: HTML entities decoded to real text, all facts pulled live from config

## Not done (deliberately)

- No `aggregateRating` — the old reviews data was removed; won't fabricate ratings.
- No explicit per-bot `robots.txt` allow lines — `*` already covers them; listing bots would be redundant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)