### PR TITLE
Pages-preview mode: render correctly on the GitHub Pages project URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,13 @@ go install github.com/wjdp/htmltest@latest
 
 ## Building & deploying
 
+> **⏳ Currently in Pages-preview mode.** The site is live for stakeholder review at
+> **<https://vijitsingh97.github.io/HiddenAcresRV/>** (the GitHub Pages project URL),
+> not yet on the real domain. `relativeURLs` is on and `static/CNAME` is removed so
+> that URL renders correctly with no redirect. **To cut over to `www.hiddenacresrv.com`:**
+> `git revert` the "Pages-preview mode" commit (restores `CNAME` + absolute URLs),
+> then set the custom domain in **Settings → Pages** and point DNS (below).
+
 ### Automatic (recommended)
 
 Pushing to the `master` branch triggers

--- a/hugo.toml
+++ b/hugo.toml
@@ -11,6 +11,21 @@ title = "Hidden Acres RV Park"
 enableRobotsTXT = true   # generates /robots.txt
 enableGitInfo = false
 
+# === PAGES-PREVIEW MODE (temporary) ==========================================
+# Stakeholders are reviewing the site on the GitHub Pages *project* URL
+# (https://vijitsingh97.github.io/HiddenAcresRV/) before we cut over to the real
+# domain. That URL serves under a /HiddenAcresRV/ subpath, so relative asset
+# links are required — with root-absolute links, every /css and /image 404s.
+# relativeURLs makes links work at BOTH the subpath now and the root domain
+# later, so no rebuild is needed at cutover. (canonical + OG stay absolute on
+# the real domain, which keeps the preview URL out of the search index.)
+#
+# CUTOVER when ready:  `git revert <this commit>`  — removes this line and
+# restores static/CNAME. Then Settings → Pages → set the custom domain and
+# point DNS (see README "Building & deploying").
+relativeURLs = true
+# =============================================================================
+
 # This is a single marketing page — turn off tags/categories and RSS feeds.
 disableKinds = ["taxonomy", "term", "rss"]
 

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,1 +1,0 @@
-www.hiddenacresrv.com


### PR DESCRIPTION
## Why

Stakeholders want to review the site at **<https://vijitsingh97.github.io/HiddenAcresRV/>** for a few days before cutting over to `www.hiddenacresrv.com`. At that URL the page was **unstyled with broken images**: it's built for the root domain, so its `/css/…` and `/image/…` paths 404 under the `/HiddenAcresRV/` subpath.

## What

- **`relativeURLs = true`** — assets become `./css/…`, which resolve at *both* the subpath now and the root domain after cutover (same build, no rebuild). `canonical` and OG stay absolute on the real domain, which keeps the preview URL out of the search index.
- **Remove `static/CNAME`** — otherwise GitHub Pages sets the custom domain from it and redirects the review URL to the not-yet-live `www.hiddenacresrv.com` (still the old nginx site). Verified: the deployed artifact currently ships `CNAME`, and Pages `cname` is unset, so removing it keeps the project URL stable and redirect-free.
- README banner noting the preview state.

## Cutover (when ready — one step)

`git revert` this commit — restores `static/CNAME` and absolute URLs — then set the custom domain in **Settings → Pages** and point DNS per the README. No content or template changes needed.

## Testing

- `./test.sh` — **33/33** (htmltest passes with relative URLs; it was the thing that broke under a subpath `baseURL`, which is why relative URLs beat changing `baseURL`)
- Verified built output: CSS/nav links relative, no `CNAME` in `public/`, canonical absolute on real domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)